### PR TITLE
No longer allow a user to set a move while it's not their turn

### DIFF
--- a/src/main/java/com/headtrixz/game/GameModel.java
+++ b/src/main/java/com/headtrixz/game/GameModel.java
@@ -1,6 +1,7 @@
 package com.headtrixz.game;
 
 import com.headtrixz.game.helpers.GameModelHelper;
+import com.headtrixz.game.players.HumanPlayer;
 import com.headtrixz.game.players.Player;
 
 public abstract class GameModel {
@@ -94,6 +95,10 @@ public abstract class GameModel {
     }
 
     public void setGuiMove(int move) {
+        if (!(currentPlayer instanceof HumanPlayer)) {
+            return;
+        }
+
         if (move == -1 || board.isValidMove(move)) {
             guiMove = move;
         }

--- a/src/main/java/com/headtrixz/game/helpers/OnlineHelper.java
+++ b/src/main/java/com/headtrixz/game/helpers/OnlineHelper.java
@@ -56,9 +56,17 @@ public class OnlineHelper implements GameModelHelper {
 
     @Override
     public void nextTurn(Player player) {
-        player.onTurn(m -> {
-            connection.getOutputHandler().move(m);
-        });
+        game.setCurrentPlayer(player);
+
+        if (player == localPlayer) {
+            player.onTurn(m -> {
+                if (m == -1) {
+                    return;
+                }
+
+                connection.getOutputHandler().move(m);
+            });
+        }
     }
 
     private final Consumer<ServerMessage> onMove = message -> {
@@ -70,6 +78,10 @@ public class OnlineHelper implements GameModelHelper {
         Platform.runLater(() -> {
             game.getController().update(move, player);
         });
+
+        if (player == localPlayer) {
+            nextTurn(game.getOpponent());
+        }
     };
 
     private final Consumer<ServerMessage> onDraw = message -> {

--- a/src/main/java/com/headtrixz/game/players/TicTacToeAI.java
+++ b/src/main/java/com/headtrixz/game/players/TicTacToeAI.java
@@ -13,7 +13,6 @@ public class TicTacToeAI extends Player {
 
     @Override
     public int getMove() {
-        // return miniMax.getMoveIterative(5000);
         return miniMax.getMove();
     }
 }


### PR DESCRIPTION
Tijdens de sprint demo was benoemd dat het mogelijk was om als gebruiker een move te zetten terwijl het niet zijn beurt was, dit was voor Tic Tac Toe geen probleem, maar zal bij Reversi problemen leveren. Hierbij de fix daarvoor.