### PR TITLE
Fix merge conflicts from #36

### DIFF
--- a/src/main/java/com/headtrixz/ui/TournamentController.java
+++ b/src/main/java/com/headtrixz/ui/TournamentController.java
@@ -39,7 +39,7 @@ public class TournamentController implements GameMethods {
     @FXML
     private StackPane containerStackPane;
     @FXML
-    private Text drawText;
+    private Text drawsText;
     @FXML
     private Text loggedInAsText;
     @FXML
@@ -139,7 +139,7 @@ public class TournamentController implements GameMethods {
      */
     private String onDraw() {
         drawCount++;
-        drawText.setText(String.format("Gelijkspel: %d", drawCount));
+        drawsText.setText(String.format("Gelijkspel: %d", drawCount));
         return "Match gelijkgespeeld tegen";
     }
 
@@ -149,8 +149,8 @@ public class TournamentController implements GameMethods {
      */
     private final InputListener onMatch = message -> {
         Map<String, String> obj = message.getObject();
-        String oppenent = obj.get("OPPONENT");
-        addToLogs("Start een match met: " + oppenent);
+        String opponent = obj.get("OPPONENT");
+        addToLogs("Start een match met: " + opponent);
 
         // TODO: Replace with factory.
         game = switch (obj.get("GAMETYPE")) {
@@ -159,12 +159,12 @@ public class TournamentController implements GameMethods {
             default -> throw new RuntimeException("Unknown type of game: " + obj.get("GAMETYPE"));
         };
 
-        Player playerOne = obj.get("PLAYERTOMOVE").equals(oppenent)
-            ? new RemotePlayer(oppenent)
+        Player playerOne = obj.get("PLAYERTOMOVE").equals(opponent)
+            ? new RemotePlayer(opponent)
             : new AIPlayer(game, username);
-        Player playerTwo = obj.get("PLAYERTOMOVE").equals(oppenent)
+        Player playerTwo = obj.get("PLAYERTOMOVE").equals(opponent)
             ? new AIPlayer(game, username)
-            : new RemotePlayer(oppenent);
+            : new RemotePlayer(opponent);
 
         GameModelHelper helper = new OnlineHelper(this, game);
         game.initialize(helper, playerOne, playerTwo);

--- a/src/main/java/com/headtrixz/ui/TournamentSettingController.java
+++ b/src/main/java/com/headtrixz/ui/TournamentSettingController.java
@@ -69,7 +69,7 @@ public class TournamentSettingController {
             if (Arrays.stream(message.getArray())
                 .anyMatch(usernameField.getText()::equalsIgnoreCase)) {
                 this.message(
-                    "Gebruiker met deze naam bestaat al. \n Kies een andere naam.", true);
+                    "Gebruiker met deze naam bestaat al. \nKies een andere naam.", true);
             } else {
                 UIManager.switchScreen("tournament");
             }

--- a/src/main/resources/com/headtrixz/ui/tournament-setting.fxml
+++ b/src/main/resources/com/headtrixz/ui/tournament-setting.fxml
@@ -96,12 +96,13 @@
             </HBox>
             <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0" GridPane.rowIndex="8" />
         </GridPane>
-           <Label fx:id="messageLabel" alignment="BOTTOM_CENTER" textFill="#002dff" />
+        <Label fx:id="messageLabel" alignment="BOTTOM_CENTER" textFill="#002dff" />
     </VBox>
       <Button fx:id="connectButton" alignment="CENTER" contentDisplay="CENTER" mnemonicParsing="false" onAction="#onConnect" prefHeight="25.0" prefWidth="312.0" text="Verbinden" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="TOP">
-      <padding>
-         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-      </padding></Button>
+          <padding>
+             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+          </padding>
+      </Button>
     <Button mnemonicParsing="false" onAction="#back" text="Terug">
         <GridPane.margin>
             <Insets left="10.0" />

--- a/src/main/resources/com/headtrixz/ui/tournament.fxml
+++ b/src/main/resources/com/headtrixz/ui/tournament.fxml
@@ -14,11 +14,11 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" spacing="5.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.headtrixz.ui.TournamentController">
+<VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" spacing="5.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.headtrixz.ui.TournamentController">
    <children>
-      <Text fx:id="title" strokeType="OUTSIDE" strokeWidth="0.0" text="Tournament modes for Tic Tac Toe" textAlignment="CENTER">
+      <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Tournament" textAlignment="CENTER">
          <font>
-            <Font size="25.0" />
+            <Font name="System Bold" size="25.0" />
          </font>
       </Text>
       <GridPane>
@@ -31,9 +31,9 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
-            <Text fx:id="winsText" fill="GREEN" strokeType="OUTSIDE" strokeWidth="0.0" text="Gewonnen: 0" />
-            <Text fx:id="drawsText" fill="BLUE" strokeType="OUTSIDE" strokeWidth="0.0" text="Gelijkspel: 0" GridPane.columnIndex="1" />
-            <Text fx:id="losesText" fill="RED" strokeType="OUTSIDE" strokeWidth="0.0" text="Verloren: 0" GridPane.columnIndex="2" />
+            <Text fx:id="winsText" fill="GREEN" strokeType="OUTSIDE" strokeWidth="0.0" text="Gewonnen: 0" GridPane.halignment="CENTER" />
+            <Text fx:id="drawsText" fill="BLUE" strokeType="OUTSIDE" strokeWidth="0.0" text="Gelijkspel: 0" GridPane.columnIndex="1" GridPane.halignment="CENTER" />
+            <Text fx:id="losesText" fill="RED" strokeType="OUTSIDE" strokeWidth="0.0" text="Verloren: 0" GridPane.columnIndex="2" GridPane.halignment="CENTER" />
          </children>
       </GridPane>
       <HBox prefHeight="279.0" prefWidth="580.0">
@@ -65,7 +65,6 @@
                   </HBox>
                   <StackPane fx:id="containerStackPane" prefHeight="264.0" prefWidth="419.0">
                      <children>
-                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Wachten op spel" />
                      </children>
                   </StackPane>
                </children>


### PR DESCRIPTION
In #36 waren een aantal merge conflicts die niet correct opgelost waren. Hierbij een fix daarvoor. 
In deze PR is de titel van het toernooi eerst nog terug veranderd naar "Tournament" (deze PR is puur voor het terugdraaien van merge conflicts), dit kan worden meegenomen in een andere PR waarin alle engelse termen worden aangepast naar het Nederlands.